### PR TITLE
Fix: Correct Gemini API model name to fix connection issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,7 +375,7 @@
                         contents: [{ role: "user", parts: [{ text: prompt }] }],
                         ...(isJson && { generationConfig: { responseMimeType: "application/json" } })
                     };
-                    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${geminiApiKey}`;
+                    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${geminiApiKey}`;
                     const response = await fetch(apiUrl, { 
                         method: 'POST', 
                         headers: { 'Content-Type': 'application/json' }, 


### PR DESCRIPTION
The application was using an incorrect model name ("gemini-2.0-flash") when calling the Google Gemini API, which caused connection failures.

This change updates the model name to "gemini-1.5-flash-latest", which is a valid and current model, to resolve the API connection issue.